### PR TITLE
obmc-mgr-system: Support GPIOs in AA, AB, AC

### DIFF
--- a/pysystemmgr/obmc/system/__init__.py
+++ b/pysystemmgr/obmc/system/__init__.py
@@ -1,9 +1,10 @@
 GPIO_BASE = 320
 
 def convertGpio(name):
-    name = name.upper()
-    c = name[0:1]
-    offset = int(name[1:])
-    a = ord(c)-65
-    base = a*8+GPIO_BASE
-    return base+offset
+    offset = int(filter(str.isdigit, name))
+    port = filter(str.isalpha, name.upper())
+    a = ord(port[-1]) - ord('A')
+    if len(port) > 1:
+        a += 26
+    base = a * 8 + GPIO_BASE
+    return base + offset


### PR DESCRIPTION
Add support for two letter GPIO names that start with A.

Signed-off-by: Xo Wang <xow@google.com>
Change-Id: Ie3a063f476f0ba84e2c8ad0415d7a6db59e8bda0